### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm

### DIFF
--- a/app/gpt.py
+++ b/app/gpt.py
@@ -5,6 +5,7 @@ import hashlib
 import random
 import uuid
 import openai
+import litellm
 from pathlib import Path
 from llama_index import ServiceContext, GPTVectorStoreIndex, LLMPredictor, RssReader, SimpleDirectoryReader, StorageContext, load_index_from_storage
 from llama_index.readers.schema.base import Document
@@ -104,11 +105,12 @@ def get_index_name_from_file(file: str):
     file_md5 = file_md5_with_extension.split('.')[0]
     return file_md5
 
+# use any of the models specified here: https://litellm.readthedocs.io/en/latest/supported/
 def get_answer_from_chatGPT(messages):
     dialog_messages = format_dialog_messages(messages)
     logging.info('=====> Use chatGPT to answer!')
     logging.info(dialog_messages)
-    completion = openai.ChatCompletion.create(
+    completion = litellm.completion(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": dialog_messages}]
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==2.2.3
 gunicorn==20.1.0
 llama-index==0.6.9
 langchain==0.0.154
+litellm==0.1.232
 httpx==0.23.3
 requests==2.28.2
 openai==0.27.1


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# async openai
response = acompletion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
